### PR TITLE
Make Swerve App button box fully clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
             </P>
             <p> A fork that's 100% community owned and governed. </p>
             <br>
-            <button class="simplebutton"><a href="https://bafybeibjrekjtc3xx6vhitcv74fwu6fag2rodg7jg7lf4z2cuhlaiwyyda.ipfs.dweb.link/#/">SWERVE APP</a></button>
+            <p><a class="simplebutton" href="https://bafybeibjrekjtc3xx6vhitcv74fwu6fag2rodg7jg7lf4z2cuhlaiwyyda.ipfs.dweb.link/#/">SWERVE APP</a></p>
             <a style="color:white" href="https://bafybeibjrekjtc3xx6vhitcv74fwu6fag2rodg7jg7lf4z2cuhlaiwyyda.ipfs.cf-ipfs.com/"> Backup IPFS Gateway </a>
             <br>
             <a style="color:white" href="https://swervefi.eth.link/#/"> via ENS Link </a>
@@ -69,7 +69,8 @@
          border: none;
          margin-right: auto;
          margin-left: auto;
-         display: flex;
+         display: block;
+         width: 100px;
          margin-bottom: 2rem !important;
          text-transform: uppercase;
          background-color: #86fce7;


### PR DESCRIPTION
Currently, the button only works if you click directly on the text.

This makes it so that the whole green button is clickable.